### PR TITLE
Interpolate time from runinfo timestep

### DIFF
--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -414,7 +414,9 @@ def _read_ndc_11_filetype_7(mm):
 
 
 def _read_ndc_11_filetype_18(mm):
-    return _read_ndc_filetype_18(mm, '<ixffff8xiiiih', 132, -63)
+    df = _read_ndc_filetype_18(mm, '<ixffff8xiiiih', 132, -16, I_mult=1/3600)
+    df['Step'] = _count_changes(df['Step'])
+    return df
 
 
 def _read_ndc_14_filetype_1(mm):
@@ -461,7 +463,9 @@ def _read_ndc_14_filetype_7(mm):
 
 
 def _read_ndc_14_filetype_18(mm):
-    return _read_ndc_filetype_18(mm, '<ixffff8xiiiih8x', 132, -4)
+    df = _read_ndc_filetype_18(mm, '<ixffff8xiiiih8x', 132, -4)
+    df["Step"] = _count_changes(df["Step"])
+    return df
 
 
 def _read_ndc_17_filetype_1(mm):
@@ -500,6 +504,7 @@ def _read_ndc_filetype_18(
         end: int,
         record_len: int = 4096,
         header_len: int = 4096,
+        I_mult: float = 1000,
 ):
     """Read runInfo ndc files.
 
@@ -538,10 +543,10 @@ def _read_ndc_filetype_18(
     df = pd.DataFrame(rec, columns=cols)
     df["Time"] /= 1000  # ms -> s
     df["dt"] /= 1000  # ms -> s
-    df["Charge_Capacity(mAh)"] *= 1000  # Ah -> mAh
-    df["Discharge_Capacity(mAh)"] *= 1000  # Ah -> mAh
-    df["Charge_Energy(mWh)"] *= 1000  # Wh -> mWh
-    df["Discharge_Energy(mWh)"] *= 1000  # Wh -> mWh
+    df["Charge_Capacity(mAh)"] *= I_mult  # -> mAh
+    df["Discharge_Capacity(mAh)"] *= I_mult  # -> mAh
+    df["Charge_Energy(mWh)"] *= I_mult  # -> mWh
+    df["Discharge_Energy(mWh)"] *= I_mult  # -> mWh
     df["Timestamp"] = pd.to_datetime(df["uts_s"] + df["ms"] / 1000, unit='s', utc=True)
 
     # Convert timestamp to local timezone


### PR DESCRIPTION
Edit 25.06.25: Not using step.xml anymore. There is a missing column in runinfo for the time steps which we can use to interpolate.

This may solve incorrect time interpolation (#4 and https://github.com/Solid-Energy-Systems/NewareNDA/issues/104).

It looks like it works on my data and the .ndax files in the tests folder, but it would be useful to test more to find edge cases.

Method
- Read Step.xml, make a mapping of step index : time record step
- Get step index from step.nda
- Add the time record steps to time, round down to nearest whole step
- Fill timestamps based on new time values (to include any that are rounded down)
- Linear interpolate whatever did not work with the same method as before

Example result
```
Orig data   Real val   New interp   Old interp
    510.0      510.0        510.0        510.0
      NaN      520.0        520.0        520.0
      NaN      530.0        530.0        530.0
      NaN      540.0        540.0        540.0
      NaN      550.0        550.0        550.0
      NaN      560.0        560.0        560.0
      NaN      570.0        570.0        570.0
    580.0      580.0        580.0        580.0
      NaN      590.0        590.0        588.0  | incorrectly interpolates
      NaN      600.0        600.0        596.1  | when other measurements
      NaN      610.0        610.0        604.1  | triggers happen
      NaN      610.0        620.0        612.2  |
    620.3      620.2        620.2        620.2  < voltage diff triggers measurement
    630.0      630.0        630.0        630.0
    640.0      640.0        640.0        640.0
      NaN      650.0        650.0        650.0
      NaN      660.0        660.0        660.0
      NaN      670.0        670.0        670.0
      NaN      680.0        680.0        680.0
      NaN      690.0        690.0        690.0
      NaN      700.0        700.0        700.0
    710.0      710.0        710.0        710.0
```

When you have multiple time record conditions, both trigger. E.g. if I have a global record 10 seconds and a step record 3 seconds, it will record at 0, 3, 6, 9, 10, 12, 15, 18, 20, 21 etc.

Luckily it looks like it registers the time when it changes between the two conditions. Only adding the smaller step seems to work:

```
Orig data   Real val   New interp   Old interp
      0.0        0.0          0.0     0.000000
      3.0        3.0          3.0     3.000000
      NaN        6.0          6.0     8.333333
      NaN        9.0          9.0    13.000000
     10.0       10.0         10.0    10.000000
     12.0       12.0         12.0    12.000000
     15.0       15.0         15.0    15.000000
      NaN       18.0         18.0    20.500000
     20.0       20.0         20.0    20.000000
     21.0       21.0         21.0    21.000000
     24.0       24.0         24.0    24.000000
      NaN       27.0         27.0    29.666666
      NaN       30.0         30.0    35.000000
      NaN       33.0         33.0    40.333332
      NaN       36.0         36.0    45.666668
      NaN       39.0         39.0    51.000000
     40.0       40.0         40.0    40.000000
     42.0       42.0         42.0    42.000000
     45.0       45.0         45.0    45.000000
      NaN       48.0         48.0    50.500000
     50.0       50.0         50.0    50.000000
     51.0       51.0         51.0    51.000000
     54.0       54.0         54.0    54.000000
      NaN       57.0         57.0    59.666668
```