### PR TITLE
NewareNDAx: ignore 1013 ndc data

### DIFF
--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -105,8 +105,12 @@ def read_ndax(file, software_cycle_number=False, cycle_mode='chg'):
         for f in zf.namelist():
 
             # If the filename contains a channel number, convert to aux_id
-            m = re.search("data_AUX_([0-9]+)_[0-9]+_[0-9]+[.]ndc", f)
-            if m:
+            m = re.search("data_AUX_([0-9]+)_([0-9]+)_[0-9]+[.]ndc", f)
+            if m and m[2] == '1013':
+                # 1013 is humidity data. Ignore for now.
+                logger.warning(f'{f} contains humidity data which will not be processed. Please open a bug report if you need this data')
+                continue
+            elif m:
                 ch = int(m[1])
                 aux_id = aux_ch_dict[ch]
             else:


### PR DESCRIPTION
1013 in ndc vresion 14, filetype 5 seems to be humidity data, and shared the same id as virtual temperature (t) data.

Make NewareNDAx ignore the humidity data until we figure out how to properly connect the aux info in TestInfo.xml with the corresponding ndc file.

Workaround for https://github.com/d-cogswell/NewareNDA/issues/3. A more proper fix is needed, at the moment the aux T data ends up as column T99, and the virtual temperature as T1, but at least NewareNDA does not crash anymore. Will try to look into it more this week or the next.