### PR TITLE
Aux channel reading fixes

### DIFF
--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -82,13 +82,9 @@ def read_ndax(file, software_cycle_number=False, cycle_mode='chg'):
             try:
                 step = zf.extract('TestInfo.xml', path=tmpdir)
                 with open(step, 'r', encoding='gb2312') as f:
-                    config = ET.fromstring(f.read()).find('config')
+                    testinfo = ET.fromstring(f.read()).find('config/TestInfo')
 
-                aux_dicts = [
-                    {k: int(v) if v.isdigit() else v for k, v in child.attrib.items()}
-                    for child in config.find("TestInfo")
-                    if "aux" in child.tag.lower()
-                ]
+                aux_dicts = [k.attrib for k in testinfo if "Aux" in k.tag] if testinfo is not None else []
 
                 # Map filenames to dicts, assume files are in same order as TestInfo.xml
                 if len(aux_dicts) == len(aux_filenames):

--- a/NewareNDA/dicts.py
+++ b/NewareNDA/dicts.py
@@ -101,7 +101,7 @@ multiplier_dict = {
 
 # Renaming aux columns by ChlType
 aux_chl_type_columns = {
-    103: "T",
-    335: "t",
-    345: "H",
+    "103": "T",
+    "335": "t",
+    "345": "H",
 }


### PR DESCRIPTION
Breaking up the changes from #16 into separate PRs

- Fixes #3 
- Try to use the aux info from TestInfo.xml to get Aux channel ID and for ndc14 file 5 the channel type (T, t, H)
- If that fails, try the Aux column
- If that fails, use an arbitrary integer (negative to avoid any overlap)
- Merge Aux dataframes into data_df on Index, instead of pivoting on Aux and merging

The file in #3 now includes columns
```
   ⋯  t1   H1        T99
0  ⋯  25.0  0.0  28.633997
1  ⋯  25.0  0.0  28.438997
⋮
```

This is slightly different to BTSDA which gives the column name as `T1(?)` instead of `T99`, but the TestInfo says `<Aux3 AuxID="99" RealChlID="99" ChlType="103" TypeID="1" VoltRange="0" TempRange="0" />` so I don't know how else it could be interpreted.

If for some reason aux files are present but TestInfo.xml cannot be read, a warning is logged and placeholder column names are used:
```
   ⋯  ?-1  ?-2        ?-3
0  ⋯  25.0  0.0  28.633997
1  ⋯  25.0  0.0  28.438997
⋮
```