### PR TITLE
Add read_metadata

### DIFF
--- a/NewareNDA/NewareNDA.py
+++ b/NewareNDA/NewareNDA.py
@@ -7,12 +7,13 @@ import mmap
 import struct
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 import pandas as pd
 
 from .utils import _generate_cycle_number, _count_changes
 from .dicts import rec_columns, dtype_dict, aux_dtype_dict, state_dict, \
     multiplier_dict
-from .NewareNDAx import read_ndax
+from .NewareNDAx import read_ndax, read_ndax_metadata
 
 logger = logging.getLogger('newarenda')
 
@@ -52,6 +53,24 @@ def read(file, software_cycle_number=True, cycle_mode='chg', log_level='INFO'):
     else:
         logger.error("File type not supported!")
         raise TypeError("File type not supported!")
+
+def read_metadata(file: str | Path) -> dict[str, str | float]:
+    """Read metadata from a Neware .nda or .ndax file.
+
+    Args:
+        file: Path of .nda or .ndax file
+
+    Returns:
+        Dictionary containing metadata
+
+    """
+    file = Path(file)
+    if file.suffix == ".nda":
+        return read_nda_metadata(file)
+    if file.suffix == ".ndax":
+        return read_ndax_metadata(file)
+    msg = "File type not supported!"
+    raise ValueError(msg)
 
 
 def read_nda(file, software_cycle_number, cycle_mode='chg'):
@@ -351,3 +370,79 @@ def _aux_bytes_to_list_BTS91(bytes):
     [Index] = struct.unpack('<I', bytes[8:12])
     [T] = struct.unpack('<f', bytes[52:56])
     return [Index, 1, T, None]
+
+
+def read_nda_metadata(file: str | Path) -> dict[str, str | int | float]:
+    """Read metadata from a Neware .nda file.
+
+    Args:
+        file: Path of .nda file to read
+
+    Returns:
+        Dictionary containing metadata
+
+    """
+    file = Path(file)
+    with file.open("rb") as f:
+        mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
+
+    if mm.read(6) != b"NEWARE":
+        msg = f"{file} does not appear to be a Neware file."
+        raise ValueError(msg)
+
+    metadata: dict[str, int | str | float] = {}
+
+    # Get the file version
+    metadata["nda_version"] = int(mm[14])
+
+    # Try to find server and client version info
+    version_loc = mm.find(b"BTSServer")
+    if version_loc != -1:
+        mm.seek(version_loc)
+        server = mm.read(50).strip(b"\x00").decode()
+        metadata["server_version"] = server
+
+        mm.seek(50, 1)
+        client = mm.read(50).strip(b"\x00").decode()
+        metadata["client_version"] = client
+    else:
+        xwj = mm.find(b"BTS_XWJ", 0, 1024)
+        if xwj != -1:
+            end = mm.find(b"\x00", xwj, 1024)
+            if end != -1:
+                metadata["server_version"] = mm[xwj:end].decode().strip()
+        else:
+            logger.info("BTS version not found!")
+
+    # NDA 29 specific fields
+    if metadata["nda_version"] == 29:
+        metadata["active_mass_mg"] = int.from_bytes(mm[152:156], "little") / 1000
+        metadata["remarks"] = mm[2317:2417].decode("ASCII", errors="ignore").replace(chr(0), "").strip()
+
+    # NDA 130 specific fields
+    elif metadata["nda_version"] == 130:
+        subver = int(mm[1024])
+        if subver == 85:
+            metadata["bts_version"] = "9.1"
+            ver = mm.find(b"9.1.")
+            if ver != -1:
+                end = mm.find(b"\x00", ver)
+                if end != 1:
+                    metadata["bts_version"] = mm[ver:end].decode()
+        elif subver == 18:
+            metadata["bts_version"] = "9.0"
+            ver = mm.find(b"9.0.")
+            if ver != -1:
+                end = mm.find(b"\x00", ver)
+                if end != 1:
+                    metadata["bts_version"] = mm[ver:end].decode()
+
+        # Identify footer
+        footer = mm.rfind(b"\x06\x00\xf0\x1d\x81\x00\x03\x00\x61\x90\x71\x90\x02\x7f\xff\x00", 1024)
+        if footer != -1:
+            mm.seek(footer + 16)
+            buf = mm.read(499)
+            metadata["active_mass_mg"] = struct.unpack("<d", buf[-8:])[0]
+            metadata["remarks"] = buf[363:491].decode("ASCII").replace(chr(0), "").strip()
+
+    return metadata

--- a/NewareNDA/NewareNDA.py
+++ b/NewareNDA/NewareNDA.py
@@ -2,6 +2,7 @@
 # Author: Daniel Cogswell
 # Email: danielcogswell@ses.ai
 
+from __future__ import annotations
 import os
 import mmap
 import struct

--- a/NewareNDA/NewareNDA.py
+++ b/NewareNDA/NewareNDA.py
@@ -2,7 +2,6 @@
 # Author: Daniel Cogswell
 # Email: danielcogswell@ses.ai
 
-from __future__ import annotations
 import os
 import mmap
 import struct
@@ -55,14 +54,14 @@ def read(file, software_cycle_number=True, cycle_mode='chg', log_level='INFO'):
         logger.error("File type not supported!")
         raise TypeError("File type not supported!")
 
-def read_metadata(file: str | Path) -> dict[str, str | float]:
+def read_metadata(file):
     """Read metadata from a Neware .nda or .ndax file.
 
     Args:
-        file: Path of .nda or .ndax file
+        file (str | Path): Path of .nda or .ndax file
 
     Returns:
-        Dictionary containing metadata
+        dict[str, str | float | dict]: Dictionary containing metadata
 
     """
     file = Path(file)
@@ -343,14 +342,14 @@ def _aux_bytes_to_list_BTS91(bytes):
     return [Index, 1, T, None]
 
 
-def read_nda_metadata(file: str | Path) -> dict[str, str | int | float]:
+def read_nda_metadata(file):
     """Read metadata from a Neware .nda file.
 
     Args:
-        file: Path of .nda file to read
+        file (str | Path): Path of .nda file to read
 
     Returns:
-        Dictionary containing metadata
+        dict[str, str | float]: Dictionary containing metadata
 
     """
     file = Path(file)

--- a/NewareNDA/NewareNDA.py
+++ b/NewareNDA/NewareNDA.py
@@ -152,19 +152,6 @@ def _read_nda_29(mm):
     """Helper function for nda version 29"""
     mm_size = mm.size()
 
-    # Get the active mass
-    [active_mass] = struct.unpack('<I', mm[152:156])
-    logger.info(f"Active mass: {active_mass/1000} mg")
-
-    try:
-        remarks = mm[2317:2417].decode('ASCII')
-        # Clean null characters
-        remarks = remarks.replace(chr(0), '').strip()
-        logger.info(f"Remarks: {remarks}")
-    except UnicodeDecodeError:
-        logger.warning("Converting remark bytes into ASCII failed")
-        remarks = ""
-
     # Identify the beginning of the data section
     record_len = 86
     identifier = b'\x00\x00\x00\x00\x55\x00'
@@ -232,23 +219,6 @@ def _read_nda_130(mm):
 
             elif bytes[0:1] == b'\x81':
                 break
-
-    # Find footer data block
-    footer = mm.rfind(b'\x06\x00\xf0\x1d\x81\x00\x03\x00\x61\x90\x71\x90\x02\x7f\xff\x00', 1024)
-    if footer != -1:
-        mm.seek(footer+16)
-        bytes = mm.read(499)
-
-        # Get the active mass
-        [active_mass] = struct.unpack('<d', bytes[-8:])
-        logger.info(f"Active mass: {active_mass} mg")
-
-        # Get the remarks
-        remarks = bytes[363:491].decode('ASCII')
-
-        # Clean null characters
-        remarks = remarks.replace(chr(0), '').strip()
-        logger.info(f"Remarks: {remarks}")
 
     return output, aux
 

--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -2,7 +2,6 @@
 # Author: Daniel Cogswell
 # Email: danielcogswell@ses.ai
 
-from __future__ import annotations
 import sys
 import mmap
 import struct
@@ -721,8 +720,16 @@ def _aux_bytes_74_to_list_ndc(bytes):
     return [Index, Aux, V/10000, T/10, t/10]
 
 
-def read_ndax_metadata(file: str | Path) -> dict[str, str | float]:
-    """Read metadata from VersionInfo.xml and Step.xml in a Neware .ndax file."""
+def read_ndax_metadata(file):
+    """Read metadata from xml files inside in a Neware .ndax file.
+    
+    Args:
+        file (str | Path): Path of .nda file to read.
+
+    Returns:
+        dict[str, str | float | dict]: Dictionary containing metadata.
+    
+    """
     metadata = {}
     with zipfile.ZipFile(str(file)) as zf:
         xml_files = [f for f in zf.namelist() if f.endswith(".xml")]

--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -2,6 +2,7 @@
 # Author: Daniel Cogswell
 # Email: danielcogswell@ses.ai
 
+from __future__ import annotations
 import sys
 import mmap
 import struct

--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -12,6 +12,8 @@ import re
 from datetime import datetime, timezone
 import xml.etree.ElementTree as ET
 import pandas as pd
+from pathlib import Path
+import xmltodict
 
 from .utils import _generate_cycle_number, _count_changes
 from .dicts import rec_columns, dtype_dict, aux_dtype_dict, state_dict, \
@@ -726,3 +728,15 @@ def _aux_bytes_74_to_list_ndc(bytes):
     [T, t] = struct.unpack('<hh', bytes[41:45])
 
     return [Index, Aux, V/10000, T/10, t/10]
+
+
+def read_ndax_metadata(file: str | Path) -> dict[str, str | float]:
+    """Read metadata from VersionInfo.xml and Step.xml in a Neware .ndax file."""
+    metadata = {}
+    with zipfile.ZipFile(str(file)) as zf:
+        xml_files = [f for f in zf.namelist() if f.endswith(".xml")]
+        for xml_file in xml_files:
+            name = xml_file.split("/")[-1].split(".")[0]
+            xml_tree = ET.fromstring(zf.read(xml_file).decode(errors="ignore")).find("config")
+            metadata[name] = xmltodict.parse(ET.tostring(xml_tree).decode(), attr_prefix="")["config"]
+    return metadata

--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -51,16 +51,6 @@ def read_ndax(file, software_cycle_number=False, cycle_mode='chg'):
         except Exception:
             pass
 
-        # Read active mass
-        try:
-            step = zf.extract('Step.xml', path=tmpdir)
-            with open(step, 'r', encoding='gb2312') as f:
-                config = ET.fromstring(f.read()).find('config')
-            active_mass = float(config.find('Head_Info/SCQ').attrib['Value'])
-            logger.info(f"Active mass: {active_mass/1000} mg")
-        except Exception:
-            pass
-
         # Find all auxiliary channel files
         # Auxiliary files files need to be matched to entries in TestInfo.xml
         # Sort by the numbers in the filename, assume same order in TestInfo.xml

--- a/NewareNDA/__init__.py
+++ b/NewareNDA/__init__.py
@@ -1,2 +1,2 @@
 from .version import __version__
-from .NewareNDA import read
+from .NewareNDA import read, read_metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ classifiers = [ "Programming Language :: Python :: 3" ]
 description = "Neware nda binary file reader."
 dependencies = [
   "pandas",
-  "importlib-metadata ~= 1.0 ; python_version < '3.8'"
+  "importlib-metadata ~= 1.0 ; python_version < '3.8'",
+  "xmltodict >= 1.0.4",
 ]
 
 [tool.setuptools.dynamic]

--- a/tests/test_NewareNDA.py
+++ b/tests/test_NewareNDA.py
@@ -32,3 +32,10 @@ def test_NewareNDAcli(nda_file, ref_file, software_cycle_number, cycle_mode):
     ref_df['Timestamp'] = ref_df['Timestamp'].apply(datetime.timestamp)
 
     pd.testing.assert_frame_equal(df, ref_df, check_like=True)
+
+
+def test_NewareNDA_metadata(nda_file, ref_file, software_cycle_number, cycle_mode):
+    """Ensure that read metadata doesn't crash and returns a non-empty dict."""
+    res = NewareNDA.read_metadata(nda_file)
+    assert isinstance(res, dict)
+    assert res


### PR DESCRIPTION
Closes #42 

Adds "read_metadata" function, copied straight from [fastnda](https://github.com/EmpaEconversion/fastnda), returns a dictionary. Adds very basic tests.

The ndax function reads all the xmls in the zip and converts everything using `xmltodict`.

The nda function is quite stupid at the moment, just grabbing particular bits of the file for different kind of nda, and I think is missing most of the metadata. I don't have any equipment that generates nda files, so I don't have much to work with.