### PR TITLE
Add count changes to ndc17 18

### DIFF
--- a/NewareNDA/NewareNDAx.py
+++ b/NewareNDA/NewareNDAx.py
@@ -669,6 +669,7 @@ def _read_ndc_17_filetype_18(mm):
         'Charge_Capacity(mAh)', 'Discharge_Capacity(mAh)',
         'Charge_Energy(mWh)', 'Discharge_Energy(mWh)',
         'Timestamp', 'Step', 'Index'])
+    df["Step"] = _count_changes(df["Step"])
 
     # Convert timestamp to local timezone
     tz = datetime.now().astimezone().tzinfo


### PR DESCRIPTION
Adds `_count_changes(df['Step'])` to `_read_ndc_17_filetype_18`

Fixes issue when there are missing steps in the ndax, which before would cause a misaligned merge

Closes #44 